### PR TITLE
Updates how we inject the privacy notice into DOM

### DIFF
--- a/privacy-notice.js
+++ b/privacy-notice.js
@@ -75,38 +75,44 @@ var addStylesheetRules = function(rules) {
 // Display privacy notice if the acknowledgment cookie isn't set
 var privacyNotice = function() {
   if (!getCookieValue(noticeCookie)) {
-    document.body.innerHTML += '<div id="privacy-notice" style="position: fixed; display: flex; justify-content: space-between; align-items: center; margin-bottom: 2rem; border-radius: 2px; padding: 1.2rem 1.6rem; border: 1px solid #000; border-top: 5px solid #000; font-weight: 600; font-size: 16px; font-family: Helvetica Neue, Helvetica, Arial, Open Sans, sans-serif; background-color: #eee; color: #000; bottom: 40px; left: 10%; right: 10%; width: 80%"><span style="margin-right: .5em;"><i class="fa fa-info-circle fa-lg" style="display: inline-block; margin-right: .5em"></i>Your online privacy is important. See the <a href="https://libraries.mit.edu/privacy" style="transition: all .25s ease-in-out 0s;">MIT Libraries privacy policy</a> for information on how we handle your data.</span><button onclick="setCookie();" style="transition: all .25s; height: 80%; border-radius: 3px; padding: 5px 10px; font-size: 16px; font-weight: 600; white-space: nowrap; color: #fff; text-decoration: none; cursor: pointer;">I understand</a></button></div>';
+    addStylesheetRules([
+      ['#privacy-notice a',
+        ['color', '#000'],
+        ['text-decoration', 'underline']
+      ],
+      ['#privacy-notice button',
+        ['background-color', '#000'],
+        ['border', '1px solid #000']
+      ],
+      ['#privacy-notice a:hover',
+        ['color', '#0000ff'],
+        ['text-decoration', 'none']
+      ],
+      ['#privacy-notice a:focus',
+        ['color', '#0000ff'],
+        ['text-decoration', 'none']
+      ],
+      ['#privacy-notice button:hover',
+        ['background-color', '#0000ff'],
+        ['border-color', '#0000ff'],
+        ['background-image', 'none']
+      ],
+      ['#privacy-notice button:focus',
+        ['background-color', '#0000ff'],
+        ['border-color', '#0000ff'],
+        ['background-image', 'none']
+      ]
+    ]);
+
+    var privacyDiv = document.createElement("div");
+    privacyDiv.setAttribute("id", "privacy-notice");
+    privacyDiv.setAttribute("style", "position: fixed; display: flex; justify-content: space-between; align-items: center; margin-bottom: 2rem; border-radius: 2px; padding: 1.2rem 1.6rem; border: 1px solid #000; border-top: 5px solid #000; font-weight: 600; font-size: 16px; font-family: Helvetica Neue, Helvetica, Arial, Open Sans, sans-serif; background-color: #eee; color: #000; bottom: 40px; left: 10%; right: 10%; width: 80%")
+    privacyDiv.innerHTML = '<span style="margin-right: .5em;"><i class="fa fa-info-circle fa-lg" style="display: inline-block; margin-right: .5em"></i>Your online privacy is important. See the <a href="https://libraries.mit.edu/privacy" style="transition: all .25s ease-in-out 0s;">MIT Libraries privacy policy</a> for information on how we handle your data.</span><button onclick="setCookie();" style="transition: all .25s; height: 80%; border-radius: 3px; padding: 5px 10px; font-size: 16px; font-weight: 600; white-space: nowrap; color: #fff; text-decoration: none; cursor: pointer;">I understand</a></button>';
+
+    document.body.appendChild(privacyDiv);
   }
 }
 
 window.onload = function() { 
-  addStylesheetRules([
-    ['#privacy-notice a',
-      ['color', '#000'],
-      ['text-decoration', 'underline']
-    ],
-    ['#privacy-notice button',
-      ['background-color', '#000'],
-      ['border', '1px solid #000']
-    ],
-    ['#privacy-notice a:hover',
-      ['color', '#0000ff'],
-      ['text-decoration', 'none']
-    ],
-    ['#privacy-notice a:focus',
-      ['color', '#0000ff'],
-      ['text-decoration', 'none']
-    ],  
-    ['#privacy-notice button:hover', 
-      ['background-color', '#0000ff'],
-      ['border-color', '#0000ff'],
-      ['background-image', 'none']
-    ],
-    ['#privacy-notice button:focus', 
-      ['background-color', '#0000ff'],
-      ['border-color', '#0000ff'],
-      ['background-image', 'none']
-    ]
-  ]);
   privacyNotice();
 }


### PR DESCRIPTION
Why are these changes being introduced:

* On our wordpress test server, the navigation dropdowns were breaking
  when the privacy notice was loaded. After accepting it the navigation
  would remain broken until the page was refreshed.

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/UXWS-1069

How does this address that need:

* The problem was isolated to how we were injecting the new div into the
  DOM. By moving to this API instead of using a += operator on the body
  InnerHTML, we are likely to have fewer conflicts with sites that have
  a bunch of weird stuff going on during the onload event.

Document any side effects to this change:

* I've also moved the adding of additional sytles to the CSS to only
  happen if the cookie is not set as we only need them if we are loading
  the notice.

#### Todo:
- [x] Stakeholder approval
